### PR TITLE
Locking PHP Composer to 1.10.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,8 @@ apt-get update --allow-unauthenticated \
 RUN apt install -y npm
 RUN npm install -g gulp
 
-# PHP Composer
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php -r "if (hash_file('sha384', 'composer-setup.php') === 'e0012edf3e80b6978849f5eff0d4b4e4c79ff1609dd1e613307e16318854d24ae64f26d17af3ef0bf7cfb710ca74755a') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+# PHP Composer 1.10.13
+RUN php -r "copy('https://raw.githubusercontent.com/composer/getcomposer.org/454bd7b5a9fd3224e8584d363e92138322fe6832/web/installer', 'composer-setup.php');" \
     && php composer-setup.php --install-dir="/usr/local/bin" --filename=composer \
     && php -r "unlink('composer-setup.php');"
 


### PR DESCRIPTION
* Installer would fail without this because the SHA is now out of date.